### PR TITLE
automate groups and user creation

### DIFF
--- a/roles/dbsoftware19c_install/tasks/main.yml
+++ b/roles/dbsoftware19c_install/tasks/main.yml
@@ -4,6 +4,22 @@
     msg:
       - 'Oracle Database Software 19c Installation started for Single Instance at {{ansible_date_time.iso8601}}:'
 
+- name: Ensure user groups exist
+  group:
+    name: "{{ oracle_install_group }}"
+    state: present
+  with_items:
+    - "{{ oracle_install_group }}"
+    - oper
+    - dba
+
+- name: Create oracle user and add to groups
+  user:
+    name: "{{ oracle_user }}"
+    state: present
+    shell: /bin/bash
+    groups: "{{ oracle_install_group }}, oper, dba, {{ sudoers_group }}"
+
 - name: create required directories
   when: inventory_hostname in groups['dbservers']
   remote_user: "{{ root_user }}"

--- a/roles/dbsoftware19c_install/vars/main.yml
+++ b/roles/dbsoftware19c_install/vars/main.yml
@@ -1,3 +1,4 @@
+sudoers_group:                   wheel
 oracle_install_group:            "oinstall"
 root_directory:                  "/u01"
 stage_dir:                       "/u01/stage"


### PR DESCRIPTION
- Ensure groups oper, oinstall and dba exist (create if not) and add oracle user to these groups
- Create oracle user and ensure it's among sudoers group. By default, sudoers group in RedHat is "wheel"