### PR TITLE
download Oracle 19c archive from server

### DIFF
--- a/roles/dbsoftware19c_install/tasks/main.yml
+++ b/roles/dbsoftware19c_install/tasks/main.yml
@@ -42,6 +42,14 @@
   tags:
    - db19c_preinstpkg
 
+- name: Download Oracle 19c archive from server
+  get_url:
+    url: "{{ oracle19c_url }}"
+    dest: "{{ stage_dir }}/LINUX.X64_193000_db_home.zip"
+    mode: '0775'
+  tags:
+    - download_oracle19c
+
 - name: Unpack Oracle 19c Database Software to the target server
   when: inventory_hostname in groups['dbservers']
   remote_user: "{{ root_user }}"

--- a/roles/dbsoftware19c_install/vars/main.yml
+++ b/roles/dbsoftware19c_install/vars/main.yml
@@ -9,3 +9,4 @@ oracle_user:                     oracle
 root_user:                       root
 oradbsoft_rsp:                   "19cEE_SoftOnly"    
 preinstall_pkg:                  "oracle-database-preinstall-19c-1.0-1.el7.src.rpm"
+oracle19c_url:                   "https://127.0.0.1/path/to/file.zip"


### PR DESCRIPTION
- Download Oracle 19c archive:
Sharing oracle19c archive from a specific point (local host in a network company, storage server, repo ...) this feature saves the trouble of downloading manually to each host